### PR TITLE
Add Poetry tool-only configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,16 @@ Currently the workspace includes the [cspell](https://github.com/streetsidesoftw
 
 ## Usage
 
-Install the dev tools:
+Install the Node.js dev tools:
 
 ```sh
 pnpm install
+```
+
+Install the Python dev tools:
+
+```sh
+poetry install --with dev
 ```
 
 Run the spell checker:

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.poetry]
+name = "universal-devtools"
+version = "0.1.0"
+description = "Python development tools for the universal monorepo."
+authors = ["Universal <dev@example.com>"]
+license = "MIT"
+readme = "README.md"
+package-mode = false
+
+[tool.poetry.dependencies]
+python = "^3.11"
+
+[tool.poetry.group.dev.dependencies]
+black = "^23.12.1"
+flake8 = "^7.0.0"
+isort = "^5.13.2"
+
+[build-system]
+requires = ["poetry-core>=1.5"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- configure Poetry to use `package-mode = false` so it's clear this isn't a package

## Testing
- `pnpm run lint:check` *(fails: mega-linter-runner not found)*
- `pnpm run format:check` *(fails: Cannot find package 'prettier-plugin-sh')*


------
https://chatgpt.com/codex/tasks/task_e_6844be71a71c832ca56509e9cf54170e