### PR TITLE
Improve devcontainer setup and docs

### DIFF
--- a/.devcontainer/features/install.sh
+++ b/.devcontainer/features/install.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Copy post-create script into a standard location
-install -Dm755 "$(dirname "$0")/post_create.py" /usr/local/share/docker-proxy-setup.py
+# Copy post-create script into a standard location.
+# The docker-proxy feature executes this script automatically
+# after the container is created to finish proxy configuration.
+install -Dm755 "$(dirname "$0")/post_create.py" \
+  /usr/local/share/docker-proxy-setup.py
 
 # Nothing else to do at build time

--- a/README.md
+++ b/README.md
@@ -24,4 +24,7 @@ Run the spell checker:
 pnpm cspell
 ```
 
+For a preconfigured development environment using Docker, see
+[Dev Container Usage](docs/devcontainer.md).
+
 📁 [View Project Tree](https://szmyty.github.io/universal//tree.md)

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -1,0 +1,36 @@
+# Dev Container Usage
+
+This repository provides a fully configured [VS Code Dev Container](https://containers.dev/) environment.
+It is designed to run on most systems that support Docker and the VS Code Dev Containers extension or the standalone `devcontainer` CLI.
+
+## Quick Start
+
+1. Install [Docker](https://docs.docker.com/get-docker/) for your platform.
+2. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) in VS Code
+   or the [`devcontainer` CLI](https://github.com/devcontainers/cli).
+3. Open this repository in VS Code and choose **"Reopen in Container"** when prompted.
+   Alternatively run:
+
+   ```bash
+   devcontainer up
+   ```
+
+The container will build the development image. The `docker-proxy` feature
+automatically runs a post-create script to finalize Docker proxy configuration.
+
+## Features
+
+- Docker-in-Docker support so you can run Docker commands inside the container.
+- Optional proxy configuration via the custom `docker-proxy` feature.
+- Development tools installed through `Taskfile.yml`.
+
+## Troubleshooting
+
+If Docker commands fail after the container starts, run the proxy setup
+manually:
+
+```bash
+python3 /usr/local/share/docker-proxy-setup.py
+```
+
+Check the `docs` directory for additional project documentation.


### PR DESCRIPTION
## Summary
- add postCreate command to run proxy setup script
- comment docker-proxy feature installation
- document dev container usage
- link dev container docs from README
- remove redundant postCreate command

## Testing
- `poetry run pre-commit run --files .devcontainer/devcontainer.json .devcontainer/features/install.sh docs/devcontainer.md` *(fails: Command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_6848a9778c64832cbc1bd6589fc96f82