### PR TITLE
Add log file support for devcontainer docker proxy

### DIFF
--- a/.devcontainer/features/README.md
+++ b/.devcontainer/features/README.md
@@ -24,3 +24,4 @@ set to `none` the proxy will be disabled.
 | `no_proxy` | Comma-separated hosts excluded from proxy | string | `` |
 | `docker_dns` | DNS server for Docker daemon | string | `8.8.8.8` |
 | `insecure_registries` | Comma separated list of insecure registries | string | `` |
+| `log_file` | File path for docker-proxy setup logs | string | `$HOME/.devtools` |

--- a/.devcontainer/features/devcontainer-feature.json
+++ b/.devcontainer/features/devcontainer-feature.json
@@ -28,6 +28,11 @@
             "type": "string",
             "default": "",
             "description": "Comma separated list of insecure registries"
+        },
+        "log_file": {
+            "type": "string",
+            "default": "$HOME/.devtools",
+            "description": "File path for docker-proxy setup logs"
         }
     },
     "containerEnv": {
@@ -38,7 +43,8 @@
         "https_proxy": "${HTTPSPROXY}",
         "no_proxy": "${NOPROXY}",
         "DOCKER_DNS": "${DOCKERDNS}",
-        "INSECURE_REGISTRIES": "${INSECUREREGISTRIES}"
+        "INSECURE_REGISTRIES": "${INSECUREREGISTRIES}",
+        "LOG_FILE": "${LOGFILE}"
     },
     "installsAfter": [
         "ghcr.io/devcontainers/features/common-utils",


### PR DESCRIPTION
## Summary
- make log file configurable for docker-proxy feature
- document `log_file` option
- write logs to that file in `post_create.py`

## Testing
- `python3 -m py_compile .devcontainer/features/post_create.py`
- `pre-commit run --files .devcontainer/features/devcontainer-feature.json .devcontainer/features/README.md .devcontainer/features/post_create.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848adb699c4832cae0bb60213bbc715