### PR TITLE
Refactor ui components into folders

### DIFF
--- a/apps/ui/src/components/Button/Button.stories.tsx
+++ b/apps/ui/src/components/Button/Button.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Button from './Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'Components/Button',
+  component: Button,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const Primary: Story = {
+  args: { children: 'Click me' },
+};

--- a/apps/ui/src/components/Button/Button.test.tsx
+++ b/apps/ui/src/components/Button/Button.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import Button from './Button';
+
+// Basic smoke test to ensure the component renders.
+// It checks that the provided children are displayed in the document.
+
+test('renders button with children', () => {
+  render(<Button>Click Me</Button>);
+  expect(screen.getByRole('button')).toHaveTextContent('Click Me');
+});

--- a/apps/ui/src/components/Button/Button.tsx
+++ b/apps/ui/src/components/Button/Button.tsx
@@ -1,0 +1,18 @@
+import type { ButtonHTMLAttributes } from 'react';
+import clsx from 'clsx';
+import type { ButtonProps } from './Button.types';
+
+// Button is a tiny wrapper around the native `<button>` element. It applies
+// Tailwind classes for a basic style but accepts all standard button
+// attributes through props.
+export default function Button({ className, ...rest }: ButtonProps) {
+  return (
+    <button
+      className={clsx(
+        'px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700',
+        className
+      )}
+      {...rest}
+    />
+  );
+}

--- a/apps/ui/src/components/Button/Button.types.ts
+++ b/apps/ui/src/components/Button/Button.types.ts
@@ -1,0 +1,7 @@
+import type { ButtonHTMLAttributes } from 'react';
+
+// Props accepted by the Button component.
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  // Optional CSS class names to apply in addition to the defaults.
+  className?: string;
+}

--- a/apps/ui/src/components/Button/index.ts
+++ b/apps/ui/src/components/Button/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Button';
+export type { ButtonProps } from './Button.types';

--- a/apps/ui/src/components/MockBanner/MockBanner.tsx
+++ b/apps/ui/src/components/MockBanner/MockBanner.tsx
@@ -1,5 +1,8 @@
-// Displays a warning banner when running in "fake" authentication mode.
-// Useful for local development when Keycloak is not available.
+// MockBanner displays a persistent banner whenever the application is running
+// in "fake" authentication mode.  This is primarily useful during local
+// development when Keycloak or another OIDC provider is not available.
+//
+// The component renders nothing when real authentication is enabled.
 export default function MockBanner() {
   if (import.meta.env.VITE_FAKE_AUTH !== "true") return null;
 

--- a/apps/ui/src/components/MockBanner/MockBanner.types.ts
+++ b/apps/ui/src/components/MockBanner/MockBanner.types.ts
@@ -1,0 +1,2 @@
+// Props for the MockBanner component. Currently empty but defined for future extensibility.
+export interface MockBannerProps {}

--- a/apps/ui/src/components/MockBanner/index.ts
+++ b/apps/ui/src/components/MockBanner/index.ts
@@ -1,1 +1,2 @@
-export * from "./MockBanner";
+export { default } from "./MockBanner";
+export type { MockBannerProps } from "./MockBanner.types";

--- a/apps/ui/src/components/PageLoader/PageLoader.tsx
+++ b/apps/ui/src/components/PageLoader/PageLoader.tsx
@@ -1,4 +1,6 @@
-// Simple loading indicator used when lazily loading pages.
+// PageLoader displays a placeholder spinner while a route component is
+// being lazily loaded.  This keeps layout shifts to a minimum during
+// asynchronous navigation.
 export default function PageLoader() {
   return (
     <div className="flex items-center justify-center h-64 text-gray-500">

--- a/apps/ui/src/components/PageLoader/index.ts
+++ b/apps/ui/src/components/PageLoader/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PageLoader';

--- a/apps/ui/src/components/index.ts
+++ b/apps/ui/src/components/index.ts
@@ -1,1 +1,7 @@
-export * from "./MockBanner";
+export { default as MockBanner } from "./MockBanner";
+export type { MockBannerProps } from "./MockBanner";
+
+export { default as PageLoader } from "./PageLoader";
+
+export { default as Button } from "./Button";
+export type { ButtonProps } from "./Button";

--- a/apps/ui/src/pages/Home.tsx
+++ b/apps/ui/src/pages/Home.tsx
@@ -1,4 +1,13 @@
 // Landing page displayed at the root URL.
+import Button from "@universal/components/Button";
+
+// The Home page is a minimal landing screen.  It showcases use of the shared
+// `Button` component as an example.
 export default function Home() {
-  return <h1 className="text-3xl font-bold">🏡 Home</h1>;
+  return (
+    <div className="space-y-4">
+      <h1 className="text-3xl font-bold">🏡 Home</h1>
+      <Button onClick={() => alert("Hello!")}>Say Hi</Button>
+    </div>
+  );
 }

--- a/apps/ui/src/routes/root.route.tsx
+++ b/apps/ui/src/routes/root.route.tsx
@@ -1,7 +1,7 @@
 // Shared layout component used as the root of the router.
 import { Outlet } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
-import MockBanner from "@universal/components//MockBanner/MockBanner";
+import MockBanner from "@universal/components/MockBanner";
 
 export function RootLayout() {
   return (

--- a/apps/ui/src/tests/setup.ts
+++ b/apps/ui/src/tests/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- reorganize React components into folders with `index.ts` and type files
- add new `Button` component as an example
- document components with comments
- show `Button` usage on the home page

## Testing
- `pnpm format:check` *(fails: Cannot find package 'prettier-plugin-sh')*
- `pnpm --filter universal-ui exec vitest run` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5ecf7cb0832c8e396a5bfdea2173