### PR TITLE
Install PDAL via multi-stage devcontainer build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@
 # reproducible.  Feel free to add or remove packages to suit your
 # project's needs.
 ######################################################################
-FROM mcr.microsoft.com/devcontainers/base@sha256:cdff177dd5755c0ba2afea60cdc0ab07d933c60d50c6c90dccbcc42b4b4ab76d
+FROM mcr.microsoft.com/devcontainers/base@sha256:cdff177dd5755c0ba2afea60cdc0ab07d933c60d50c6c90dccbcc42b4b4ab76d AS deps
 
 # Override the default temporary directory if needed. Useful when
 # working on filesystems where /tmp has limited space.
@@ -238,3 +238,23 @@ RUN chmod +x /workspace/scripts/devtools.sh && \
     bash /workspace/scripts/devtools.sh && \
     rm -rf /workspace/scripts && \
     chown --recursive vscode:vscode "${DEVTOOLS_HOME}"
+
+######################################################################
+# PDAL build stage
+######################################################################
+FROM deps AS pdal-build
+
+# Commit to build and its SHA256 checksum
+ARG PDAL_SHA=bba54fc27c4476d1571318dd43259c59e86cdc84
+ARG PDAL_SHA256=14bc6b06eb1c0c2bea865913741916a9f54e29b7e6da26c7c0e2f9d19d1ba3a4
+
+COPY scripts/install_pdal.sh /workspace/scripts/install_pdal.sh
+RUN chmod +x /workspace/scripts/install_pdal.sh && \
+    bash /workspace/scripts/install_pdal.sh "${PDAL_SHA}" "${PDAL_SHA256}" && \
+    rm /workspace/scripts/install_pdal.sh
+
+######################################################################
+# Final image with PDAL installed
+######################################################################
+FROM deps
+COPY --from=pdal-build /usr/local/ /usr/local/

--- a/scripts/install_pdal.sh
+++ b/scripts/install_pdal.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# Script: install-pdal.sh
+# Description: Builds and installs PDAL from a specific commit with optional
+#              SHA256 verification.
+# -----------------------------------------------------------------------------
+
+log()   { printf "👉 %s\n" "$*" >&2; }
+error() { printf "❌ %s\n" "$*" >&2; exit 1; }
+
+download_pdal() {
+  log "📥 Downloading PDAL source from ${URL}"
+  curl --fail --location --output "$ARCHIVE" "$URL"
+}
+
+verify_checksum() {
+  echo "${CHECKSUM}  ${ARCHIVE}" | sha256sum -c -
+  log "✅ SHA256 checksum verified"
+}
+
+extract_source() {
+  log "📦 Extracting source"
+  tar -xf "$ARCHIVE" -C "$WORK_DIR"
+  SRC_DIR="$(find "$WORK_DIR" -maxdepth 1 -type d -name 'PDAL-*' | head -n 1)"
+}
+
+build_pdal() {
+  mkdir -p "$SRC_DIR/build"
+  cd "$SRC_DIR/build"
+  log "🔨 Configuring build"
+  cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${PREFIX}"
+  log "🚀 Building PDAL"
+  make -j"$(nproc)"
+}
+
+install_pdal() {
+  log "📂 Installing to ${PREFIX}"
+  make install
+}
+
+main() {
+  SHA="${1:-}"
+  CHECKSUM="${2:-}"
+  PREFIX="${3:-/usr/local}"
+
+  [[ -z "$SHA" ]] && error "PDAL commit SHA required"
+
+  WORK_DIR="$(mktemp -d)"
+  trap 'rm -rf "$WORK_DIR"' EXIT
+
+  ARCHIVE="${WORK_DIR}/pdal.tar.gz"
+  URL="https://github.com/PDAL/PDAL/archive/${SHA}.tar.gz"
+
+  download_pdal
+  if [[ -n "$CHECKSUM" ]]; then
+    verify_checksum
+  else
+    log "⚠️ No SHA256 provided — skipping verification"
+  fi
+
+  extract_source
+  build_pdal
+  install_pdal
+
+  log "🎉 PDAL installation complete"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- build PDAL from a pinned commit
- verify the download checksum
- copy PDAL install artifacts into the final devcontainer image
- refactor the `install_pdal.sh` helper script into functions with a main entrypoint

## Testing
- `pre-commit run --files .devcontainer/Dockerfile scripts/install_pdal.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fa15bda48832c930760cb96b4ac7d