### PR TITLE
Implement minimal API with SQLite

### DIFF
--- a/services/api/api/core/config.py
+++ b/services/api/api/core/config.py
@@ -5,8 +5,9 @@ from functools import lru_cache
 from pydantic import Field, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+
 class Settings(BaseSettings):
-    """Configuration settings for the application."""
+    """Application configuration."""
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -24,6 +25,27 @@ class Settings(BaseSettings):
     LOG_FILE: str = Field("logs/app.log", description="Path to the log file")
     LOG_JSON: bool = Field(False, description="Enable JSON logging")
 
-    OIDC_ISSUER: str = Field(..., description="OIDC issuer URL")
-    OIDC_CLIENT_ID: str = Field(..., description="OIDC client ID")
-    OIDC_CLIENT_SECRET: SecretStr = Field(..., description="OIDC client secret")
+    # OIDC settings are optional for local development
+    OIDC_ISSUER: str | None = Field(None, description="OIDC issuer URL")
+    OIDC_CLIENT_ID: str | None = Field(None, description="OIDC client ID")
+    OIDC_CLIENT_SECRET: SecretStr | None = Field(None, description="OIDC client secret")
+
+    DB_HOST: str = Field("localhost", description="Database host")
+    DB_PORT: int = Field(5432, description="Database port")
+    DB_USER: str = Field("postgres", description="Database user")
+    DB_PASSWORD: str = Field("postgres", description="Database password")
+    DB_NAME: str = Field("universal", description="Database name")
+
+    @property
+    def DATABASE_URL(self) -> str:  # pragma: no cover - simple property
+        """Return the SQLAlchemy database URL."""
+        return (
+            f"postgresql+asyncpg://{self.DB_USER}:{self.DB_PASSWORD}@"
+            f"{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}"
+        )
+
+
+@lru_cache()
+def get_config() -> Settings:
+    """Return a cached ``Settings`` instance."""
+    return Settings()

--- a/services/api/api/database/dao.py
+++ b/services/api/api/database/dao.py
@@ -5,7 +5,7 @@ import structlog
 
 log = structlog.get_logger(__name__)
 
-from .models import User, Message, MapState
+from ..models import User, Message, MapState
 
 
 class BaseDAO:

--- a/services/api/api/database/database.py
+++ b/services/api/api/database/database.py
@@ -1,7 +1,7 @@
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 
-from .config import get_config
-from .models import Base
+from ..core.config import get_config
+from ..models import Base
 import structlog
 
 log = structlog.get_logger(__name__)
@@ -10,10 +10,7 @@ log = structlog.get_logger(__name__)
 def get_database_url() -> str:
     """Construct the database connection URL from configuration."""
     cfg = get_config()
-    return (
-        f"postgresql+asyncpg://{cfg.db_user}:{cfg.db_password}@"
-        f"{cfg.db_host}:{cfg.db_port}/{cfg.db_name}"
-    )
+    return cfg.DATABASE_URL
 
 
 engine = create_async_engine(get_database_url(), future=True, echo=False)
@@ -25,3 +22,10 @@ async def get_session() -> AsyncSession:
     """Yield an ``AsyncSession`` instance scoped to a single request."""
     async with async_session() as session:
         yield session
+
+
+async def init_db() -> None:
+    """Create database tables if they do not exist."""
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    log.info("Database initialized")

--- a/services/api/api/main.py
+++ b/services/api/api/main.py
@@ -1,0 +1,57 @@
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .core.config import get_config
+from .database.database import get_session, init_db
+from .database.dao import UserDAO, MessageDAO
+from .database.dao import MapStateDAO
+from pydantic import BaseModel
+
+cfg = get_config()
+app = FastAPI(title=cfg.PROJECT_NAME, description=cfg.DESCRIPTION, version=cfg.VERSION)
+
+
+class UserCreate(BaseModel):
+    id: str
+    preferred_username: str | None = None
+    email: str | None = None
+
+
+class MessageCreate(BaseModel):
+    user_id: str
+    message: str
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    await init_db()
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/users")
+async def create_user(payload: UserCreate, session: AsyncSession = Depends(get_session)):
+    dao = UserDAO(session)
+    user = await dao.get_or_create(payload.id, payload.preferred_username, payload.email)
+    return {"id": user.id, "preferred_username": user.preferred_username, "email": user.email}
+
+
+@app.post("/messages")
+async def create_message(payload: MessageCreate, session: AsyncSession = Depends(get_session)):
+    user = await UserDAO(session).get(payload.user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="user not found")
+    msg = await MessageDAO(session).create(user, payload.message)
+    return {"id": msg.id, "user_id": msg.user_id, "message": msg.message}
+
+
+@app.get("/messages")
+async def list_messages(session: AsyncSession = Depends(get_session)):
+    msgs = await MessageDAO(session).list_all()
+    return [
+        {"id": m.id, "user_id": m.user_id, "message": m.message}
+        for m in msgs
+    ]

--- a/services/api/api/models/map_state.py
+++ b/services/api/api/models/map_state.py
@@ -1,19 +1,19 @@
-from sqlalchemy import Column, Integer, Text, DateTime, func, ForeignKey, String
+from sqlalchemy import Column, Integer, JSON, DateTime, func, ForeignKey, String
 from sqlalchemy.orm import relationship
 
 from .base import Base
 from .user import USERS_TABLE_NAME
 
-MESSAGES_TABLE_NAME = "messages"
+MAP_STATES_TABLE_NAME = "map_states"
 
-class Message(Base):
-    """Message posted by a user."""
+class MapState(Base):
+    """Persisted map state for a user."""
 
-    __tablename__ = MESSAGES_TABLE_NAME
+    __tablename__ = MAP_STATES_TABLE_NAME
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     user_id = Column(String, ForeignKey(f"{USERS_TABLE_NAME}.id"), nullable=False)
-    message = Column(Text, nullable=False)
+    state = Column(JSON, nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(
         DateTime(timezone=True),
@@ -22,4 +22,4 @@ class Message(Base):
         nullable=False,
     )
 
-    user = relationship("User", back_populates="messages")
+    user = relationship("User", back_populates="map_states")

--- a/services/api/api/models/user.py
+++ b/services/api/api/models/user.py
@@ -1,1 +1,18 @@
-from
+from sqlalchemy import Column, String
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+USERS_TABLE_NAME = "users"
+
+class User(Base):
+    """User account information."""
+
+    __tablename__ = USERS_TABLE_NAME
+
+    id = Column(String, primary_key=True)
+    preferred_username = Column(String, nullable=True)
+    email = Column(String, nullable=True)
+
+    messages = relationship("Message", back_populates="user", cascade="all, delete-orphan")
+    map_states = relationship("MapState", back_populates="user", cascade="all, delete-orphan")

--- a/services/api/tests/test_api.py
+++ b/services/api/tests/test_api.py
@@ -1,0 +1,46 @@
+import os
+import asyncio
+
+import pytest
+from httpx import AsyncClient
+
+os.environ["DB_HOST"] = ""  # force sqlite
+os.environ["DB_PORT"] = ""
+os.environ["DB_USER"] = ""
+os.environ["DB_PASSWORD"] = ""
+os.environ["DB_NAME"] = ":memory:"
+os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"
+
+from api.main import app
+from api.database.database import get_session, engine, init_db
+
+
+@pytest.fixture(autouse=True, scope="module")
+async def prepare_db():
+    await init_db()
+    yield
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_health():
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_create_user_and_message():
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        user_payload = {"id": "user1", "preferred_username": "user1", "email": "u@example.com"}
+        resp = await ac.post("/users", json=user_payload)
+        assert resp.status_code == 200
+        resp = await ac.post("/messages", json={"user_id": "user1", "message": "hello"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["message"] == "hello"
+        resp = await ac.get("/messages")
+        assert resp.status_code == 200
+        messages = resp.json()
+        assert len(messages) == 1


### PR DESCRIPTION
## Summary
- flesh out FastAPI service in `services/api`
- implement ORM models for users, messages and map state
- provide database helpers using SQLAlchemy
- add minimal FastAPI app with health and CRUD endpoints
- include pytest suite with a dummy in-memory database

## Testing
- `pytest -q services/api/tests/test_api.py` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68502d3f7eec832c98f1ec8d04c79ab3