### PR TITLE
Add DTO models to API

### DIFF
--- a/services/api/api/__init__.py
+++ b/services/api/api/__init__.py
@@ -1,0 +1,19 @@
+"""API package initialization."""
+
+from .dto import (
+    UserCreate,
+    UserRead,
+    MessageCreate,
+    MessageRead,
+    MapStateCreate,
+    MapStateRead,
+)
+
+__all__ = [
+    "UserCreate",
+    "UserRead",
+    "MessageCreate",
+    "MessageRead",
+    "MapStateCreate",
+    "MapStateRead",
+]

--- a/services/api/api/dto.py
+++ b/services/api/api/dto.py
@@ -1,0 +1,30 @@
+from pydantic import BaseModel
+from typing import Optional, Dict, Any
+
+class UserCreate(BaseModel):
+    id: str
+    preferred_username: Optional[str] = None
+    email: Optional[str] = None
+
+class UserRead(BaseModel):
+    id: str
+    preferred_username: Optional[str] = None
+    email: Optional[str] = None
+
+class MessageCreate(BaseModel):
+    user_id: str
+    message: str
+
+class MessageRead(BaseModel):
+    id: int
+    user_id: str
+    message: str
+
+class MapStateCreate(BaseModel):
+    user_id: str
+    state: Dict[str, Any]
+
+class MapStateRead(BaseModel):
+    id: int
+    user_id: str
+    state: Dict[str, Any]

--- a/services/api/api/main.py
+++ b/services/api/api/main.py
@@ -5,21 +5,18 @@ from .core.config import get_config
 from .database.database import get_session, init_db
 from .database.dao import UserDAO, MessageDAO
 from .database.dao import MapStateDAO
-from pydantic import BaseModel
+from .dto import (
+    UserCreate,
+    UserRead,
+    MessageCreate,
+    MessageRead,
+)
 
 cfg = get_config()
 app = FastAPI(title=cfg.PROJECT_NAME, description=cfg.DESCRIPTION, version=cfg.VERSION)
 
 
-class UserCreate(BaseModel):
-    id: str
-    preferred_username: str | None = None
-    email: str | None = None
 
-
-class MessageCreate(BaseModel):
-    user_id: str
-    message: str
 
 
 @app.on_event("startup")
@@ -32,26 +29,36 @@ async def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
-@app.post("/users")
-async def create_user(payload: UserCreate, session: AsyncSession = Depends(get_session)):
+@app.post("/users", response_model=UserRead)
+async def create_user(
+    payload: UserCreate, session: AsyncSession = Depends(get_session)
+) -> UserRead:
     dao = UserDAO(session)
-    user = await dao.get_or_create(payload.id, payload.preferred_username, payload.email)
-    return {"id": user.id, "preferred_username": user.preferred_username, "email": user.email}
+    user = await dao.get_or_create(
+        payload.id, payload.preferred_username, payload.email
+    )
+    return UserRead(
+        id=user.id,
+        preferred_username=user.preferred_username,
+        email=user.email,
+    )
 
 
-@app.post("/messages")
-async def create_message(payload: MessageCreate, session: AsyncSession = Depends(get_session)):
+@app.post("/messages", response_model=MessageRead)
+async def create_message(
+    payload: MessageCreate, session: AsyncSession = Depends(get_session)
+) -> MessageRead:
     user = await UserDAO(session).get(payload.user_id)
     if not user:
         raise HTTPException(status_code=404, detail="user not found")
     msg = await MessageDAO(session).create(user, payload.message)
-    return {"id": msg.id, "user_id": msg.user_id, "message": msg.message}
+    return MessageRead(id=msg.id, user_id=msg.user_id, message=msg.message)
 
 
-@app.get("/messages")
-async def list_messages(session: AsyncSession = Depends(get_session)):
+@app.get("/messages", response_model=list[MessageRead])
+async def list_messages(session: AsyncSession = Depends(get_session)) -> list[MessageRead]:
     msgs = await MessageDAO(session).list_all()
     return [
-        {"id": m.id, "user_id": m.user_id, "message": m.message}
+        MessageRead(id=m.id, user_id=m.user_id, message=m.message)
         for m in msgs
     ]


### PR DESCRIPTION
## Summary
- introduce DTO models for user, message, and map state
- export DTOs from `api` package
- use DTOs in API endpoints for request and response handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685099206048832cb2d95b4ef79f2668