### PR TITLE
Add dev Keycloak realm import

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ Start the UI in dev mode with:
 ```bash
 pnpm --filter universal-ui dev
 ```
+
+## Runtime Environments
+
+Docker Compose files allow switching between `development`, `demo`, and `production` stacks. The development configuration automatically imports a Keycloak realm from `services/keycloak/development-realm.json` so local users and roles are available out of the box.

--- a/docs/tree.md
+++ b/docs/tree.md
@@ -48,9 +48,12 @@
 ├── services
 │   ├── api
 │   │   └── README.md
+│   ├── keycloak
+│   │   ├── README.md
+│   │   └── development-realm.json
 │   └── README.md
 ├── Taskfile.yml
 └── universal.code-workspace
 
-10 directories, 40 files
+11 directories, 42 files
 ```

--- a/services/README.md
+++ b/services/README.md
@@ -3,3 +3,4 @@
 Server side applications live here. Each folder is an independent service.
 
 - **api** – Placeholder for the upcoming backend API implementation.
+- **keycloak** – Container configuration and a development realm export.

--- a/services/keycloak/README.md
+++ b/services/keycloak/README.md
@@ -1,0 +1,7 @@
+# Keycloak Service
+
+This directory stores configuration for the Keycloak container used in development.
+
+The `development-realm.json` file contains a preconfigured realm with sample users and roles. When the development Docker Compose stack is started, this realm is imported automatically.
+
+Production and demo environments require a manually configured realm; no import occurs.

--- a/services/keycloak/development-realm.json
+++ b/services/keycloak/development-realm.json
@@ -1,0 +1,30 @@
+{
+    "realm": "development",
+    "enabled": true,
+    "roles": {
+        "realm": [
+            {"name": "admin"},
+            {"name": "user"}
+        ]
+    },
+    "users": [
+        {
+            "username": "admin",
+            "email": "admin@example.com",
+            "enabled": true,
+            "credentials": [
+                {"type": "password", "value": "password"}
+            ],
+            "realmRoles": ["admin"]
+        },
+        {
+            "username": "user",
+            "email": "user@example.com",
+            "enabled": true,
+            "credentials": [
+                {"type": "password", "value": "password"}
+            ],
+            "realmRoles": ["user"]
+        }
+    ]
+}

--- a/universal.development.yml
+++ b/universal.development.yml
@@ -19,6 +19,10 @@ services:
     env_file:
       - .env.universal
       - .env.development
+    environment:
+      KEYCLOAK_IMPORT: /opt/keycloak/data/import/development-realm.json
+    volumes:
+      - ./services/keycloak/development-realm.json:/opt/keycloak/data/import/development-realm.json:ro
 
   pgadmin:
     env_file:


### PR DESCRIPTION
## Summary
- auto-import a Keycloak realm when running the dev stack
- document the new Keycloak service
- list the Keycloak folder in the project tree
- describe runtime environment switching in README

## Testing
- `pnpm lint:spellcheck` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_685b41f491a0832cba46fdf2262df171