### PR TITLE
Integrate message CRUD with Keycloak

### DIFF
--- a/apps/ui/src/api/apiSlice.ts
+++ b/apps/ui/src/api/apiSlice.ts
@@ -1,0 +1,80 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import type { Message, MessageCreate, MessageUpdate } from "@universal/models";
+
+const localStorageKey = `oidc.user:${import.meta.env.VITE_KEYCLOAK_URL}:${import.meta.env.VITE_KEYCLOAK_CLIENT_ID}`;
+
+const baseQuery = fetchBaseQuery({
+  baseUrl: '/api',
+  prepareHeaders: (headers) => {
+    try {
+      const raw = localStorage.getItem(localStorageKey);
+      if (raw) {
+        const data = JSON.parse(raw);
+        if (data?.access_token) {
+          headers.set('Authorization', `Bearer ${data.access_token}`);
+        }
+        if (data?.profile?.sub) {
+          headers.set('X-User-Id', data.profile.sub);
+        }
+      }
+    } catch {
+      // Ignore parsing errors
+    }
+    return headers;
+  },
+});
+
+export const api = createApi({
+  reducerPath: 'api',
+  baseQuery,
+  tagTypes: ['Message'],
+  endpoints: (builder) => ({
+    listMyMessages: builder.query<Message[], void>({
+      query: () => "/messages/me",
+      providesTags: (result) =>
+        result
+          ? [
+              ...result.map(({ id }) => ({ type: "Message" as const, id })),
+              { type: "Message", id: "LIST" },
+            ]
+          : [{ type: "Message", id: "LIST" }],
+    }),
+    getMessage: builder.query<Message, number>({
+      query: (id) => `/messages/${id}`,
+      providesTags: (result, error, id) => [{ type: "Message", id }],
+    }),
+    createMessage: builder.mutation<Message, MessageCreate>({
+      query: (body) => ({
+        url: "/messages",
+        method: "POST",
+        body,
+      }),
+      invalidatesTags: [{ type: "Message", id: "LIST" }],
+    }),
+    updateMessage: builder.mutation<Message, MessageUpdate & { id: number }>({
+      query: ({ id, ...patch }) => ({
+        url: `/messages/${id}`,
+        method: "PUT",
+        body: patch,
+      }),
+      invalidatesTags: (result, error, { id }) => [{ type: "Message", id }],
+    }),
+    deleteMessage: builder.mutation<{ success: boolean }, number>({
+      query: (id) => ({
+        url: `/messages/${id}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: (result, error, id) => [
+        { type: "Message", id },
+        { type: "Message", id: "LIST" },
+      ],
+    }),
+  }),
+});
+export const {
+  useListMyMessagesQuery,
+  useGetMessageQuery,
+  useCreateMessageMutation,
+  useUpdateMessageMutation,
+  useDeleteMessageMutation,
+} = api;

--- a/apps/ui/src/api/index.ts
+++ b/apps/ui/src/api/index.ts
@@ -1,0 +1,2 @@
+export * from './apiSlice';
+export * from './store';

--- a/apps/ui/src/api/store.ts
+++ b/apps/ui/src/api/store.ts
@@ -1,0 +1,13 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { api } from './apiSlice';
+
+export const store = configureStore({
+  reducer: {
+    [api.reducerPath]: api.reducer,
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(api.middleware),
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/apps/ui/src/main.tsx
+++ b/apps/ui/src/main.tsx
@@ -3,13 +3,17 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "@universal/styles/app.css";
 import { UniversalAuthProvider } from "@universal/auth";
+import { Provider } from "react-redux";
+import { store } from "@universal/api";
 import App from "./App";
 
 // Render the root component tree under <div id="root"> in index.html.
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <UniversalAuthProvider>
-      <App />
-    </UniversalAuthProvider>
+    <Provider store={store}>
+      <UniversalAuthProvider>
+        <App />
+      </UniversalAuthProvider>
+    </Provider>
   </React.StrictMode>
 );

--- a/apps/ui/src/models/Message.ts
+++ b/apps/ui/src/models/Message.ts
@@ -1,0 +1,18 @@
+import type { OIDCUser } from './User';
+
+export interface Message {
+  id: number;
+  user_id: string;
+  user: OIDCUser;
+  content: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MessageCreate {
+  content: string;
+}
+
+export interface MessageUpdate {
+  content: string;
+}

--- a/apps/ui/src/models/User.ts
+++ b/apps/ui/src/models/User.ts
@@ -85,3 +85,27 @@ export const hasRole = (
 
     return false;
 };
+
+// OIDC user info returned from the API
+export interface OIDCUser {
+    sub: string;
+    preferred_username?: string;
+    email?: string;
+    given_name?: string;
+    family_name?: string;
+    name?: string;
+    picture?: string;
+    locale?: string;
+    roles?: string[];
+    groups?: string[];
+    extra?: Record<string, any>;
+}
+
+
+// Basic user entity returned from the API layer
+export type ApiUser = {
+    id: string;
+    username: string;
+    email: string;
+    roles?: UserRole[];
+};

--- a/apps/ui/src/models/index.ts
+++ b/apps/ui/src/models/index.ts
@@ -1,2 +1,4 @@
 export * from "./user";
+export * from "./User";
+export * from "./Message";
 export * from "./user.mock";


### PR DESCRIPTION
## Summary
- add OIDC user interface and message models
- expose RTK Query hooks for message CRUD using logged-in user headers
- export models in barrel file

## Testing
- `pnpm lint` *(fails: registry access blocked)*
- `pnpm run typecheck` *(fails: registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b7a1f7a80832ca78b7438642ecb92