### PR TITLE
Add message generation endpoint

### DIFF
--- a/services/api/src/app/api/routes/messages.py
+++ b/services/api/src/app/api/routes/messages.py
@@ -40,6 +40,18 @@ async def create_message(
     return MessageRead.model_validate(created)
 
 
+@router.get("/generate", response_model=MessageRead, status_code=status.HTTP_201_CREATED)
+async def generate_message(
+    user: OIDCUser = Depends(map_oidc_user),
+    service: MessageService = Depends(get_message_service),
+) -> MessageRead:
+    """Generate a random message for the current user."""
+    created: MessageDomain = await service.generate(user.sub)
+    created.user = user
+    log.info("Generated message", message_id=created.id, user_id=user.sub)
+    return MessageRead.model_validate(created)
+
+
 @router.get("/", response_model=list[MessageRead])
 async def list_all_messages(
     user: OIDCUser = Depends(map_oidc_user),

--- a/services/api/src/app/services/message_service.py
+++ b/services/api/src/app/services/message_service.py
@@ -1,4 +1,5 @@
 from typing import Sequence
+from uuid import uuid4
 
 from app.domain.messages.interfaces import MessageRepository
 from app.schemas.messages import MessageCreate, MessageUpdate
@@ -35,3 +36,8 @@ class MessageService:
     async def delete(self, id: int) -> bool:
         """Delete a message by ID."""
         return await self.repo.delete(id)
+
+    async def generate(self, user_id: str) -> MessageDomain:
+        """Generate and create a random message for the given user."""
+        content = f"Hello from ChatGPT {uuid4()}"
+        return await self.repo.create(user_id, content)

--- a/services/api/tests/api/test_messages_api.py
+++ b/services/api/tests/api/test_messages_api.py
@@ -99,3 +99,14 @@ class TestMessagesApi:
             # Confirm it's gone
             fetch_resp: Response = await client.get(f"/api/messages/{message_id}")
             assert fetch_resp.status_code == status.HTTP_404_NOT_FOUND
+
+    async def test_generate_message(self, test_app: FastAPI) -> None:
+        """Should generate and return a random message."""
+        async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+            resp: Response = await client.get("/api/messages/generate")
+            assert resp.status_code == status.HTTP_201_CREATED
+
+            data = resp.json()
+            assert data["user_id"] == "test-user-id"
+            assert data["content"].startswith("Hello from ChatGPT")
+            assert isinstance(MessageRead.model_validate(data), MessageRead)

--- a/services/api/tests/services/test_messages_service.py
+++ b/services/api/tests/services/test_messages_service.py
@@ -84,3 +84,17 @@ class TestMessageService:
         # Assert
         assert deleted is True
         assert fetched is None
+
+    async def test_generate_message(self: TestMessageService, db_session: AsyncSession) -> None:
+        """Should generate a random message and store it."""
+        dao = MessageDAO(db_session)
+        repo = SqlAlchemyMessageRepository(dao)
+        service = MessageService(repo)
+
+        generated: MessageDomain = await service.generate("user-gen")
+        fetched: MessageDomain | None = await service.get(generated.id)
+
+        assert fetched is not None
+        assert fetched.id == generated.id
+        assert fetched.user_id == "user-gen"
+        assert fetched.content.startswith("Hello from ChatGPT")


### PR DESCRIPTION
## Summary
- implement `generate` method in `MessageService`
- expose new GET `/api/messages/generate` endpoint
- cover new feature with service and API tests

## Testing
- `poetry run pytest tests/services/test_messages_service.py::TestMessageService::test_generate_message -q` *(fails: Missing required plugins)*

------
https://chatgpt.com/codex/tasks/task_e_6861cbfb35f0832ca0b4ff3820a4fe4c