### PR TITLE
Add blog category carousel

### DIFF
--- a/apps/ui/src/components/CategoryCard/CategoryCard.tsx
+++ b/apps/ui/src/components/CategoryCard/CategoryCard.tsx
@@ -1,0 +1,26 @@
+import { motion } from 'framer-motion';
+import type { BlogCategory } from '@/data/blogCategories';
+
+export interface CategoryCardProps {
+  category: BlogCategory;
+}
+
+export default function CategoryCard({ category }: CategoryCardProps) {
+  return (
+    <motion.div
+      whileHover={{ scale: 1.05 }}
+      className="relative w-40 h-24 flex-shrink-0 rounded overflow-hidden shadow"
+    >
+      <img
+        src={category.image || '/assets/categories/placeholder.jpg'}
+        alt={category.name}
+        className="absolute inset-0 w-full h-full object-cover"
+      />
+      <div className="absolute inset-0 bg-black/40 flex items-end transition-opacity hover:bg-black/30">
+        <span className="text-white p-2 text-sm font-semibold">
+          {category.name}
+        </span>
+      </div>
+    </motion.div>
+  );
+}

--- a/apps/ui/src/components/CategoryCard/index.ts
+++ b/apps/ui/src/components/CategoryCard/index.ts
@@ -1,0 +1,2 @@
+export { default } from './CategoryCard';
+export type { CategoryCardProps } from './CategoryCard';

--- a/apps/ui/src/components/CategoryCarousel.tsx
+++ b/apps/ui/src/components/CategoryCarousel.tsx
@@ -1,0 +1,22 @@
+import CategoryCard from './CategoryCard';
+import type { BlogCategory } from '@/data/blogCategories';
+import { motion } from 'framer-motion';
+
+export interface CategoryCarouselProps {
+  categories: BlogCategory[];
+}
+
+export default function CategoryCarousel({ categories }: CategoryCarouselProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      className="flex space-x-4 overflow-x-auto pb-2"
+    >
+      {categories.map((cat) => (
+        <CategoryCard key={cat.name} category={cat} />
+      ))}
+    </motion.div>
+  );
+}

--- a/apps/ui/src/data/blogCategories.ts
+++ b/apps/ui/src/data/blogCategories.ts
@@ -1,0 +1,66 @@
+export interface BlogCategory {
+  name: string;
+  image: string;
+}
+
+export interface BlogCategoryGroup {
+  name: string;
+  categories: BlogCategory[];
+}
+
+export const blogCategoryGroups: BlogCategoryGroup[] = [
+  {
+    name: "Mental & Cognitive",
+    categories: [
+      { name: "psychology", image: "/assets/categories/psychology.jpg" },
+      { name: "neurology", image: "/assets/categories/neurology.jpg" },
+      { name: "cognitive science", image: "/assets/categories/cognitive-science.jpg" },
+      { name: "behavioral science", image: "/assets/categories/behavioral-science.jpg" },
+      { name: "identity", image: "/assets/categories/identity.jpg" },
+      { name: "habit formation", image: "/assets/categories/habit-formation.jpg" },
+      { name: "self-discipline", image: "/assets/categories/self-discipline.jpg" },
+    ],
+  },
+  {
+    name: "Spiritual & Transpersonal",
+    categories: [
+      { name: "spirituality", image: "/assets/categories/spirituality.jpg" },
+      { name: "metaphysics", image: "/assets/categories/metaphysics.jpg" },
+      { name: "consciousness studies", image: "/assets/categories/consciousness-studies.jpg" },
+      { name: "shadow work", image: "/assets/categories/shadow-work.jpg" },
+      { name: "archetypes", image: "/assets/categories/archetypes.jpg" },
+      { name: "ritual", image: "/assets/categories/ritual.jpg" },
+      { name: "alchemy", image: "/assets/categories/alchemy.jpg" },
+      { name: "dreamwork", image: "/assets/categories/dreamwork.jpg" },
+    ],
+  },
+  {
+    name: "Body & Embodiment",
+    categories: [
+      { name: "meditation", image: "/assets/categories/meditation.jpg" },
+      { name: "breathwork", image: "/assets/categories/breathwork.jpg" },
+      { name: "somatics", image: "/assets/categories/somatics.jpg" },
+      { name: "healing", image: "/assets/categories/healing.jpg" },
+    ],
+  },
+  {
+    name: "Philosophical & Reflective",
+    categories: [
+      { name: "philosophy", image: "/assets/categories/philosophy.jpg" },
+      { name: "existentialism", image: "/assets/categories/existentialism.jpg" },
+      { name: "ethics", image: "/assets/categories/ethics.jpg" },
+      { name: "symbolism", image: "/assets/categories/symbolism.jpg" },
+      { name: "journaling", image: "/assets/categories/journaling.jpg" },
+      { name: "downloads", image: "/assets/categories/downloads.jpg" },
+      { name: "synapse", image: "/assets/categories/synapse.jpg" },
+    ],
+  },
+  {
+    name: "Systems & External",
+    categories: [
+      { name: "systems thinking", image: "/assets/categories/systems-thinking.jpg" },
+      { name: "technology", image: "/assets/categories/technology.jpg" },
+      { name: "information theory", image: "/assets/categories/information-theory.jpg" },
+    ],
+  },
+];

--- a/apps/ui/src/pages/Blog.tsx
+++ b/apps/ui/src/pages/Blog.tsx
@@ -1,0 +1,16 @@
+import CategoryCarousel from '@/components/CategoryCarousel';
+import { blogCategoryGroups } from '@/data/blogCategories';
+
+export default function Blog() {
+  return (
+    <div className="space-y-8">
+      <h1 className="text-3xl font-bold">Blog Categories</h1>
+      {blogCategoryGroups.map((group) => (
+        <section key={group.name} className="space-y-2">
+          <h2 className="text-2xl font-semibold">{group.name}</h2>
+          <CategoryCarousel categories={group.categories} />
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/ui/src/pages/index.ts
+++ b/apps/ui/src/pages/index.ts
@@ -5,3 +5,4 @@ export * from "./Home";
 export * from "./NoAccess";
 export * from "./NotFound";
 export * from "./SuperAdmin";
+export * from "./Blog";

--- a/apps/ui/src/routes/blog.route.tsx
+++ b/apps/ui/src/routes/blog.route.tsx
@@ -1,0 +1,16 @@
+import { createRoute } from '@tanstack/react-router';
+import { rootRoute } from './index';
+import { lazy, Suspense } from 'react';
+import { PageLoader } from '@universal/components';
+
+const LazyBlog = lazy(() => import('../pages/Blog').then((m) => ({ default: m.default })));
+
+export const blogRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/blog',
+  component: () => (
+    <Suspense fallback={<PageLoader />}>
+      <LazyBlog />
+    </Suspense>
+  ),
+});

--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -4,6 +4,7 @@ import { homeRoute } from "./home.route";
 import { aboutRoute } from "./about.route";
 import { adminRoute } from "./admin.route";
 import { superAdminRoute } from "./superadmin.route";
+import { blogRoute } from "./blog.route";
 
 import { lazy, Suspense } from "react";
 import { PageLoader } from "@universal/components";
@@ -29,6 +30,7 @@ export const routeTree = rootRoute.addChildren([
   aboutRoute,
   adminRoute,
   superAdminRoute,
+  blogRoute,
 ]);
 
 export const router = createRouter(

--- a/apps/ui/src/routes/root.route.tsx
+++ b/apps/ui/src/routes/root.route.tsx
@@ -13,6 +13,7 @@ export function RootLayout() {
           <a href="/about" onMouseEnter={() => import("../pages/About.js")}>About</a>
           <a href="/admin" onMouseEnter={() => import("../pages/Admin.js")}>Admin</a>
           <a href="/superadmin" onMouseEnter={() => import("../pages/SuperAdmin.js")}>Super Admin</a>
+          <a href="/blog" onMouseEnter={() => import("../pages/Blog.js")}>Blog</a>
         </nav>
       </header>
 


### PR DESCRIPTION
## Summary
- add data for blog category groups
- display category cards in a horizontally scrollable carousel
- create Blog page and route
- link Blog page in navigation

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_687b28fe0bbc832ca1d36b1f4fba6b8a