### PR TITLE
Add Lynis auditing setup

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -42,6 +42,7 @@ We use the following tools to **automate security checks**:
 - **[Snyk](https://snyk.io/)** → Scans for vulnerabilities in dependencies.
 - **[Trivy](https://aquasecurity.github.io/trivy/)** → Security scanning for containers.
 - **[Gitleaks](https://github.com/gitleaks/gitleaks)** → Detects secrets in Git commits.
+- **[Lynis](https://github.com/CISOfy/lynis)** → Audits system configuration.
 
 🔗 **You can run security scans manually using:**
 ```sh

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,6 +15,7 @@ includes:
   utils: ./tasks/utils.yml
   dev: ./tasks/dev.yml
   write: ./tasks/write.yml
+  security: ./tasks/security.yml
 
 tasks:
   setup:

--- a/config/lynis/custom.prf
+++ b/config/lynis/custom.prf
@@ -1,0 +1,6 @@
+# Custom Lynis profile for repository audits
+# Logs and reports saved in the repository under reports/lynis
+logfile=reports/lynis/lynis.log
+report_file=reports/lynis/report.dat
+use-colors=no
+quiet=yes

--- a/docs/lynis.md
+++ b/docs/lynis.md
@@ -1,0 +1,30 @@
+# Lynis Security Auditing
+
+[Lynis](https://github.com/CISOfy/lynis) is a security auditing tool for Unix based systems.
+This repository ships a small configuration and Taskfile commands to run audits.
+
+## Installation
+
+Run the installation script which fetches a pinned release from GitHub:
+
+```bash
+# Installs to /usr/local/lynis and creates /usr/local/bin/lynis
+scripts/install_lynis.sh
+```
+
+You can override the version or prefix path by providing arguments:
+
+```bash
+scripts/install_lynis.sh 3.1.1 /opt
+```
+
+## Running an Audit
+
+Use the Taskfile wrapper to execute Lynis with the repo configuration:
+
+```bash
+task lynis:system
+```
+
+Logs and reports are written to `reports/lynis/`.
+

--- a/scripts/install_lynis.sh
+++ b/scripts/install_lynis.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# install_lynis.sh - Download and install Lynis from GitHub
+set -euo pipefail
+
+VERSION="${1:-3.1.1}"
+PREFIX="${2:-/usr/local}"
+
+LYNIS_URL="https://github.com/CISOfy/lynis/archive/refs/tags/v${VERSION}.tar.gz"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "📥 Downloading Lynis ${VERSION}"
+curl --fail --location --output "$WORK_DIR/lynis.tar.gz" "$LYNIS_URL"
+
+echo "📦 Extracting"
+tar -xf "$WORK_DIR/lynis.tar.gz" -C "$WORK_DIR"
+LYNIS_SRC="$(find "$WORK_DIR" -maxdepth 1 -type d -name "lynis-*" | head -n 1)"
+
+install -d "${PREFIX}/lynis"
+cp -r "$LYNIS_SRC"/* "${PREFIX}/lynis/"
+ln -sf "${PREFIX}/lynis/lynis" /usr/local/bin/lynis
+
+echo "✅ Lynis installed to ${PREFIX}/lynis"

--- a/tasks/security.yml
+++ b/tasks/security.yml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: "3"
+
+tasks:
+  lynis:install:
+    desc: Install Lynis from GitHub
+    cmds:
+      - bash scripts/install_lynis.sh
+    silent: true
+
+  lynis:system:
+    desc: Run Lynis system audit
+    cmds:
+      - |
+        mkdir -p reports/lynis
+        lynis audit system --profile config/lynis/custom.prf
+    silent: true


### PR DESCRIPTION
## Summary
- include new security taskfile with Lynis commands
- install script to fetch Lynis releases
- minimal profile file under `config/lynis`
- document usage in `docs/lynis.md`
- mention Lynis in security documentation
- register the security taskfile in `Taskfile.yml`

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c670b8f38832c96972444015124e2